### PR TITLE
add zustand devtools

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { initializeDebugTools } from "./utils/debugInitializer";
+
+// Initialize debug tools for development
+initializeDebugTools();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>

--- a/src/stores/audioStore.ts
+++ b/src/stores/audioStore.ts
@@ -55,7 +55,7 @@ interface AudioState {
   handleAudioError: () => void;
 }
 
-export const useAudioStore = create<AudioState>((set, get) => ({
+export const useAudioStore = create<AudioState>()((set, get) => ({
   // Initial state
   currentPlayingAudioUrl: null,
   resolvedPlayingAudioUrl: null,

--- a/src/stores/rootDebugStore.ts
+++ b/src/stores/rootDebugStore.ts
@@ -1,0 +1,77 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { useAudioStore } from './audioStore';
+import { useDebugStore } from './debugStore';
+import { useNotesStore } from './notesStore';
+import { useRecordingStore } from './recordingStore';
+import { useSettingsStore } from './settingsStore';
+import { useTranscriptionStore } from './transcriptionStore';
+import { useLLMProvidersStore } from './llmProvidersStore';
+import { useAgentsStore } from './agentsStore';
+import { useRoutingStore } from './routingStore';
+import { useAppStore } from './appStore';
+
+// Type for the root debug store
+interface RootDebugState {
+  // This store doesn't need its own state, it's just for debugging
+  // We'll add a method to get the current state of all stores
+  getAllStores: () => Record<string, any>;
+}
+
+// Create the root debug store with devtools middleware
+export const useRootDebugStore = create<RootDebugState>()(
+  devtools(
+    (set, get) => ({
+      getAllStores: () => ({
+        audio: useAudioStore.getState(),
+        debug: useDebugStore.getState(),
+        notes: useNotesStore.getState(),
+        recording: useRecordingStore.getState(),
+        settings: useSettingsStore.getState(),
+        transcription: useTranscriptionStore.getState(),
+        llmProviders: useLLMProvidersStore.getState(),
+        agents: useAgentsStore.getState(),
+        routing: useRoutingStore.getState(),
+        app: useAppStore.getState(),
+      }),
+    }),
+    {
+      name: 'Bolt-Voice-Notes',
+      enabled: process.env.NODE_ENV === 'development',
+    }
+  )
+);
+
+// Function to initialize devtools for all stores
+export const initializeDevTools = () => {
+  if (process.env.NODE_ENV !== 'development') {
+    return; // Only run in development
+  }
+
+  // Subscribe to all stores to update the devtools when any store changes
+  const subscribeToStore = (store: any, name: string) => {
+    store.subscribe((state: any) => {
+      // Update the devtools with the new state
+      useRootDebugStore.setState(
+        { [name]: state },
+        false, // replace: false to merge with existing state
+        `${name}/updated` // action name for devtools
+      );
+    });
+  };
+
+  // Subscribe to all stores
+  subscribeToStore(useAudioStore, 'audio');
+  subscribeToStore(useDebugStore, 'debug');
+  subscribeToStore(useNotesStore, 'notes');
+  subscribeToStore(useRecordingStore, 'recording');
+  subscribeToStore(useSettingsStore, 'settings');
+  subscribeToStore(useTranscriptionStore, 'transcription');
+  subscribeToStore(useLLMProvidersStore, 'llmProviders');
+  subscribeToStore(useAgentsStore, 'agents');
+  subscribeToStore(useRoutingStore, 'routing');
+  subscribeToStore(useAppStore, 'app');
+
+  // Initialize with current state
+  useRootDebugStore.setState(useRootDebugStore.getState().getAllStores());
+};

--- a/src/utils/debugInitializer.ts
+++ b/src/utils/debugInitializer.ts
@@ -1,0 +1,12 @@
+import { initializeDevTools } from '../stores/rootDebugStore';
+
+/**
+ * Initialize debug tools for development environment
+ * This is a no-op in production
+ */
+export const initializeDebugTools = () => {
+  if (process.env.NODE_ENV === 'development') {
+    console.log('Initializing Zustand DevTools');
+    initializeDevTools();
+  }
+};


### PR DESCRIPTION
# Add Zustand DevTools Integration

## Summary
This PR adds Redux DevTools integration for all Zustand stores in the application through a centralized debug store approach. This makes it easier to debug state changes during development without modifying the core functionality of individual stores.

## Changes
- Created a new `rootDebugStore` that aggregates all store states in one place
- Added a debug initializer utility that only runs in development mode
- Connected all existing stores to the debug system without modifying their core functionality
- Initialized the debug tools in the app's entry point

## Implementation Details
- Used a non-invasive approach that keeps individual stores "agnostic" of debugging tools
- The debug store acts as a central hub that collects state from all stores and exposes it to Redux DevTools
- All debug functionality is development-only and won't affect production builds
- Store subscriptions ensure that all state changes are properly tracked in the DevTools

## Testing
To test this implementation:
1. Run the app in development mode
2. Open Redux DevTools in your browser
3. You should see all store states and their changes in the DevTools panel
4. Verify that actions like adding notes, playing audio, etc. are properly tracked

## Next Steps
- Consider adding more detailed action names for better debugging
- Explore selective state tracking for performance optimization in larger stores
